### PR TITLE
Removed deprecated property - spring.datasource.initialization-mode

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=beer-service
 sfg.brewery.beer-inventory-service-host=http://localhost:8082
 sfg.brewery.inventory-user=good
 sfg.brewery.inventory-password=beer
-spring.datasource.initialization-mode=EMBEDDED
+spring.sql.init.mode=embedded
 spring.cache.jcache.config=classpath:ehcache.xml
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL
 spring.h2.console.enabled=true


### PR DESCRIPTION
This property is deprecated and should be replaced with `spring.sql.init.mode=embedded`