### PR TITLE
Deferring DB Initialization

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@ sfg.brewery.beer-inventory-service-host=http://localhost:8082
 sfg.brewery.inventory-user=good
 sfg.brewery.inventory-password=beer
 spring.datasource.initialization-mode=EMBEDDED
+spring.jpa.defer-datasource-initialization=true
 spring.cache.jcache.config=classpath:ehcache.xml
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL
 spring.h2.console.enabled=true


### PR DESCRIPTION
For data.sql to execute successfully, H2 DB creation should be deferred. Otherwise a `org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "BEER" not found` is being thrown.
Adding `spring.jpa.defer-datasource-initialization=true` to `application.properties` solves this issue.